### PR TITLE
Remove PTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 - [LogikIO](https://github.com/LogikIO) - Logik.IO. ([Join](https://orgmanager.miguelpiedrafita.com/o/LogikIO))
 - [miRTop](https://github.com/miRTop) - miRNA transcriptome open project. ([Join](https://orgmanager.miguelpiedrafita.com/o/miRTop))
 - [SlyFoxStudios](https://github.com/SlyFoxStudios) - We are a game making group. Here to release our games source code. ([Join](https://orgmanager.miguelpiedrafita.com/o/SlyFoxStudios))
-- [Programmers' Thinking Pub](https://github.com/ptp) - A place for developers to chat and collaborate. ([Join](https://orgmanager.miguelpiedrafita.com/o/ptp) - Needs a password, ask for it!)
 - [libscode](https://github.com/libscode) - The development resource project based on information technology. ([Join](https://orgmanager.miguelpiedrafita.com/o/libscode))
 - [GitIndonesia](https://github.com/GitIndonesia) - Komunitas Git Indonesia. ([Join](https://orgmanager.miguelpiedrafita.com/o/GitIndonesia))
 


### PR DESCRIPTION
Remove the Programmers' Thinking Pub organization from the list, as it isn't a full open organization (requires password)