### PR TITLE
Changed fossasia join link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - [OrgManager](https://github.com/orgmanager) - Supercharge your GitHub organizations! ([Join](https://orgmanager.miguelpiedrafita.com/o/orgmanager))
 - [Open Source Design](https://github.com/opensourcedesign) - Bringing together designers and open source projects, join us on IRC #opensourcedesign. ([Join](https://orgmanager.miguelpiedrafita.com/o/opensourcedesign))
-- [FOSSASIA](https://github.com/fossasia) - Open Technologies in Asia. ([Join](https://github.com/fossasia/fossasia.org/issues/new?title=Join%20FOSSASIA&body=Hi,%20could%20you%20invite%20me%20to%20the%20FOSSASIA%20GitHub%20organization?))
+- [FOSSASIA](https://github.com/fossasia) - Open Technologies in Asia. ([Join](https://orgmanager.miguelpiedrafita.com/o/fossasia))
 - [AppStackTop](https://github.com/AppStackTop) - AppStack. ([Join](https://orgmanager.miguelpiedrafita.com/o/AppStackTop))
 - [LogikIO](https://github.com/LogikIO) - Logik.IO. ([Join](https://orgmanager.miguelpiedrafita.com/o/LogikIO))
 - [miRTop](https://github.com/miRTop) - miRNA transcriptome open project. ([Join](https://orgmanager.miguelpiedrafita.com/o/miRTop))


### PR DESCRIPTION
The join link to FOSSASIA in this repository ends up creating an issue in the repository (https://github.com/fossasia/fossasia.org) which ends up getting closed by FOSSASIA and may be annoying to them. I have amended that link with the prescribed (https://orgmanager.miguelpiedrafita.com/o/fossasia).
